### PR TITLE
ci : build and push dev to Google Cloud

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -1,0 +1,72 @@
+name: Build and push image from ref
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "A ref from this repository, CirclesUBI/api-server"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "A ref from this repository, CirclesUBI/api-server"
+        required: true
+        type: string
+
+env:
+  IMAGE_NAME: api-server
+
+jobs:
+
+  build-and-push-image:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+
+    -
+      name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.ref }}
+
+    -
+      name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    -
+      name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: |
+          ${{ vars.GC_REGISTRY }}/${{ vars.GC_PROJECT }}/${{ env.IMAGE_NAME }}
+        tags: |
+          ${{ inputs.ref }}
+          {{ ref_name }}
+          {{ sha }}
+
+    -
+      name: Authenticate to Google Cloud
+      id: auth
+      uses: google-github-actions/auth@v1
+      with:
+        workload_identity_provider: "${{ vars.GC_WLI_PROVIDER }}"
+        service_account:            "${{ vars.GC_WLI_SA }}"
+
+    -
+      name: Login to Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ vars.GC_REGISTRY }}
+        username: 'oauth2accesstoken'
+        password: '${{ steps.auth.outputs.access_token }}'
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v3
+      with:
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,67 +1,14 @@
-name: deploy dev
+name: Build and push the dev image
 
 on:
   push:
     branches: [ dev ]
-  pull_request:
-    branches: [ dev ]
-
-env:
-  REGISTRY: registry.digitalocean.com
-  IMAGE_OWNER: circles-land
-  IMAGE_REPOSITORY: api-server
 
 jobs:
-  build-docker-image:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
+  call-build-and-push:
     steps:
-      -
-        name: Checkout repository
-        uses: actions/checkout@v3
-
-      - id: readPackageJson
-        run: |
-          content=`cat ./package.json`
-          # the following lines are only required for multi line json
-          content="${content//'%'/'%25'}"
-          content="${content//$'\n'/'%0A'}"
-          content="${content//$'\r'/'%0D'}"
-          # end of optional handling for multi line json
-          echo "::set-output name=packageJson::$content"
-
-      -
-        name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: |
-            ${{ env.REGISTRY }}/${{ env. IMAGE_OWNER }}/${{ env.IMAGE_REPOSITORY }}
-          tags: |
-            latest
-            {{sha}}
-            {{branch}}
-            {{base_ref}}
-            ${{fromJson(steps.readPackageJson.outputs.packageJson).version}}{{branch}}
-            ${{fromJson(steps.readPackageJson.outputs.packageJson).version}}{{base_ref}}
-
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      -
-        name: Login to Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.DIGITALOCEAN_PASSWORD }}
-          password: ${{ secrets.DIGITALOCEAN_PASSWORD }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v3
-        with:
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+    -
+      name: Trigger container build and push
+      uses: ./.github/workflows/build-and-push
+      with:
+        ref: {{ ref }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,9 @@
 name: deploy main
+
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
+
 jobs:
   build-docker-image:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,3 @@ RUN /usr/o-platform/api-server/build.sh
 
 WORKDIR /usr/o-platform/api-server/dist
 CMD ["node", "main.js"]
-


### PR DESCRIPTION
This brings a refactoring of the workflow for building and pushing images from the `dev` branch.

- add: A new workflow `build-and-push.yaml` with `workflow_dispatch` and `workflow_call` triggers is provided, that takes a `ref` as its input.
- upd: `dev.yml` is remodeled to call that workflow with its `ref`
- chore: cosmetic changes in the Dockerfile
- chore: removal of the `pull_request` trigger on the `main.yml` workflow

We need to merge this, to see if it's picked up by the `on.push: ["dev"]` trigger.