### PR TITLE
Update init container

### DIFF
--- a/Dockerfile.init
+++ b/Dockerfile.init
@@ -2,7 +2,7 @@ FROM postgres:15
 
 WORKDIR /docker-entrypoint-initdb.d/
 
-RUN <<load.sh /docker-entrypoint-initdb.d/
+COPY <<load.sh /docker-entrypoint-initdb.d/
 #!/bin/bash
 set -x
 ls ${PWD} | xargs -I% psql postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@${POSTGRES_HOST:-localhost}:${POSTGRES_PORT:-5432}${POSTGRES_DB:-postgres} < %

--- a/Dockerfile.init
+++ b/Dockerfile.init
@@ -5,7 +5,7 @@ WORKDIR /docker-entrypoint-initdb.d/
 COPY <<load.sh /docker-entrypoint-initdb.d/
 #!/bin/bash
 set -x
-ls ${PWD} | xargs -I% psql postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@${POSTGRES_HOST:-localhost}:${POSTGRES_PORT:-5432}${POSTGRES_DB:-postgres} < %
+ls ${PWD}/*.sql | xargs -I% psql postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@${POSTGRES_HOST:-localhost}:${POSTGRES_PORT:-5432}${POSTGRES_DB:-postgres} < %
 load.sh
 
 RUN chmod +x /docker-entrypoint-initdb.d/load.sh

--- a/Dockerfile.init
+++ b/Dockerfile.init
@@ -2,13 +2,13 @@ FROM postgres:15
 
 WORKDIR /docker-entrypoint-initdb.d/
 
-RUN touch /docker-entrypoint-initdb.d/load.sh \
-      chmod +x load.sh \
-      cat <<EOF >> load.sh
-      #!/bin/bash
-      set -x
-      ls ${PWD} | xargs -I% psql postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@${POSTGRES_HOST:-localhost}:${POSTGRES_PORT:-5432}${POSTGRES_DB:-postgres} < %
-      EOF
+RUN <<load.sh /docker-entrypoint-initdb.d/
+#!/bin/bash
+set -x
+ls ${PWD} | xargs -I% psql postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@${POSTGRES_HOST:-localhost}:${POSTGRES_PORT:-5432}${POSTGRES_DB:-postgres} < %
+load.sh
+
+RUN chmod +x /docker-entrypoint-initdb.d/load.sh
 
 COPY ./src/api-db-migrations/ /docker-entrypoint-initdb.d/
 


### PR DESCRIPTION
This uses the Dockerfile heredoc notation for creating our `CMD` script, and only loads `*.sql` files into the database.