### PR TITLE
upd : init container

### DIFF
--- a/Dockerfile.init
+++ b/Dockerfile.init
@@ -5,7 +5,7 @@ WORKDIR /docker-entrypoint-initdb.d/
 COPY <<load.sh /docker-entrypoint-initdb.d/
 #!/bin/bash
 set -x
-ls /docker-entrypoint-initdb.d/*.sql | xargs -I% psql ${CONNECTION_STRING_RW} < %
+ls /docker-entrypoint-initdb.d/*.sql | xargs -I% sh -c 'psql ${CONNECTION_STRING_RW} < %'
 load.sh
 
 RUN chmod +x /docker-entrypoint-initdb.d/load.sh


### PR DESCRIPTION
Uses correct string interpolation syntax for `xargs` chaining with replacement strings *and* shell string substitution from environment.