### PR TITLE
fix(ci): pin buildkit version

### DIFF
--- a/.github/workflows/build-and-push-dockerfile.yml
+++ b/.github/workflows/build-and-push-dockerfile.yml
@@ -52,6 +52,9 @@ jobs:
     -
       name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
+      with:
+        driver-opts: |
+          image=moby/buildkit:v0.10.6
 
     -
       name: Docker meta
@@ -89,7 +92,8 @@ jobs:
         username: 'oauth2accesstoken'
         password: '${{ steps.auth.outputs.access_token }}'
 
-    - name: Build and push Docker image
+    - 
+      name: Build and push Docker image
       uses: docker/build-push-action@v3
       with:
         push: true

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -44,6 +44,9 @@ jobs:
     -
       name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
+      with:
+        driver-opts: |
+          image=moby/buildkit:v0.10.6
 
     -
       name: Docker meta
@@ -81,7 +84,8 @@ jobs:
         username: 'oauth2accesstoken'
         password: '${{ steps.auth.outputs.access_token }}'
 
-    - name: Build and push Docker image
+    - 
+      name: Build and push Docker image
       uses: docker/build-push-action@v3
       with:
         push: true


### PR DESCRIPTION
GitHub Action runners have recently shown regressions when pushing images to different registries after release of Docker's Moby BuildKit 0.11.0 last week.

For now we are pinning the BuildKit version to a known working version, until upstream is resolved.