### PR TITLE
feat(ci): add release drafter

### DIFF
--- a/.github/release-drafter.dev.yml
+++ b/.github/release-drafter.dev.yml
@@ -1,0 +1,11 @@
+template: |
+  ## What’s Changed
+
+  $CHANGES
+
+name-template: "v$NEXT_PATCH_VERSION"
+tag-template: "v$NEXT_PATCH_VERSION"
+version-template: "$COMPLETE"
+
+include-labels:
+  - 'release/next'

--- a/.github/workflows/release-drafter.dev.yml
+++ b/.github/workflows/release-drafter.dev.yml
@@ -1,0 +1,25 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - dev
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "dev"
+      - uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter.dev.yml
+          disable-autolabeler: true
+          prerelease: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This introduces a configuration for the release drafter action to prepare releases from, in this case, `dev` to `next`.

- https://github.com/marketplace/actions/release-drafter#include-pull-requests