### PR TITLE
Connecting SurveyData to Profile on First Registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@o-platform/api-server",
-  "version": "0.1.514",
+  "version": "0.1.515",
   "description": "",
   "main": "dist/index.js",
   "prepublish": "tsc",

--- a/src/api-db/schema_template.prisma
+++ b/src/api-db/schema_template.prisma
@@ -11,11 +11,12 @@ generator client {
 
 model SurveyData {
     id Int @id @default(autoincrement())
-    sesssionId String
+    sesssionId String @unique
     allConsentsGiven Boolean
     userType String
     gender String
     dateOfBirth DateTime
+    profilesWithSurveyData Profile[] @relation("Profile_SurveyDataSessionId")   
 }
 
 model Session {
@@ -393,7 +394,7 @@ model Profile {
     cancelledInvoices Invoice[] @relation(name: "Invoice_CancelledByProfile")
 
     inviteTrigger Job? @relation(name: "Profile_InviteTrigger", fields: [inviteTriggerId], references: [id])
-    inviteTriggerId Int?
+    inviteTriggerId Int? @unique
 
     invoiceNoPrefix String? @default("I-")
     lastInvoiceNo Int? // Is used in organisations only and represents the current value of the invoice number series.
@@ -427,6 +428,9 @@ model Profile {
     businessHoursSaturday String?
     businessHoursSunday String?
     phoneNumber String?
+    surveyDataSession SurveyData? @relation(name: "Profile_SurveyDataSessionId", fields: [surveyDataSessionId], references: [sesssionId]) 
+    surveyDataSessionId String? @unique
+      
 }
 
 model Favorites {

--- a/src/server-schema.graphql
+++ b/src/server-schema.graphql
@@ -66,6 +66,7 @@ type Profile {
   lat: Float
   lon: Float
   category: BusinessCategory
+  surveyDataSessionId: String
 }
 
 input ContactFilter {
@@ -178,6 +179,7 @@ input UpsertProfileInput {
   locationName: String
   lat: Float
   lon: Float
+  surveyDataSessionId: String
 }
 
 type Tag {

--- a/src/types.ts
+++ b/src/types.ts
@@ -778,6 +778,7 @@ export type Profile = {
   smallBannerUrl?: Maybe<Scalars['String']>;
   status?: Maybe<Scalars['String']>;
   successorOfCirclesAddress?: Maybe<Scalars['String']>;
+  surveyDataSessionId?: Maybe<Scalars['String']>;
   type?: Maybe<ProfileType>;
   verifications?: Maybe<Array<Verification>>;
 };
@@ -1370,6 +1371,7 @@ export type UpsertProfileInput = {
   newsletter?: InputMaybe<Scalars['Boolean']>;
   status: Scalars['String'];
   successorOfCirclesAddress?: InputMaybe<Scalars['String']>;
+  surveyDataSessionId?: InputMaybe<Scalars['String']>;
 };
 
 export type UpsertTagInput = {
@@ -2275,6 +2277,7 @@ export type ProfileResolvers<ContextType = any, ParentType extends ResolversPare
   smallBannerUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   status?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   successorOfCirclesAddress?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  surveyDataSessionId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   type?: Resolver<Maybe<ResolversTypes['ProfileType']>, ParentType, ContextType>;
   verifications?: Resolver<Maybe<Array<ResolversTypes['Verification']>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;


### PR DESCRIPTION
adding the surveydatasession Id to the profile.
adjusting mutations to store the id

This is on purpose NOT set to 'required' otherwise on every upsert after the initial registration it will want the ID,
and we don't want to send the ID back to the client as then people could use it to retrieve personal user data from the Graphql....

So the check if the data is there is done in promtRegistration 