### PR TITLE
APP-366: fix(migrations/container): sslmode cases

### DIFF
--- a/Dockerfile.migrations
+++ b/Dockerfile.migrations
@@ -14,7 +14,7 @@ COPY <<load.sh /
 envsubst < /db/migrations/20230606172700__add_root_user.sql.envsubst > /db/migrations/20230606172700__add_root_user.sql
 rm /db/migrations/20230606172700__add_root_user.sql.envsubst
 
-[[ "$CONNECTION_STRING_RW" == *sslmode* ]] && export CONNECTION_STRING_RW=$\{CONNECTION_STRING_RW/no-verify/require\}
+[[ "$CONNECTION_STRING_RW" == *sslmode* ]] && CONNECTION_STRING_RW=$\{CONNECTION_STRING_RW/no-verify/require\}
 
 /usr/local/bin/dbmate -e CONNECTION_STRING_RW --no-dump-schema migrate
 load.sh

--- a/Dockerfile.migrations
+++ b/Dockerfile.migrations
@@ -14,7 +14,8 @@ COPY <<load.sh /
 envsubst < /db/migrations/20230606172700__add_root_user.sql.envsubst > /db/migrations/20230606172700__add_root_user.sql
 rm /db/migrations/20230606172700__add_root_user.sql.envsubst
 
-export CONNECTION_STRING_RW=$\{CONNECTION_STRING_RW\}?sslmode=disable
+[[ "$CONNECTION_STRING_RW" == *sslmode* ]] && export CONNECTION_STRING_RW=$\{CONNECTION_STRING_RW/no-verify/require\}
+
 /usr/local/bin/dbmate -e CONNECTION_STRING_RW --no-dump-schema migrate
 load.sh
 RUN chmod +x /load.sh


### PR DESCRIPTION
This fixes a regression with databases connections that set an explicit `sslmode`. Previously we had disabled it for all cases, assuming no parameter would be provided.

This time we adapt to the possible case, in which an SSL mode is provided, but in a notation not known by PostgreSQL.
We have seen cases, in which `no-verify` is specified for configuring the `api-server` `psql` client, which we set to `require`, instead of the (possibly insecure) default of `prefer`.

To cite https://www.postgresql.org/docs/current/libpq-ssl.html#LIBQ-SSL-CERTIFICATES

    "By default, PostgreSQL will not perform
    any verification of the server certificate."

This differs from the default in the Postgres library we use `pq`, citing https://node-postgres.com/announcements#2020-02-25

    "Now we will use the default ssl options to tls.connect
    which includes rejectUnauthorized being enabled.
    This means your connection attempt may fail
    if you are using a self-signed cert."

As per that announcement, the behaviour is intentionally inherited from:

- https://nodejs.org/api/tls.html#tls_tls_connect_options_callback

As specifying an `sslmode`, even with `no-verify`, implies that we want to enforce a secure connection, we are falling back to a sane default, `require`.

Reference:

- https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-SSLMODE-STATEMENTS
- https://github.com/brianc/node-postgres/blob/46cfb25baf8fdba87f71c3888fcb0021eaf829d3/packages/pg-connection-string/README.md?plain=1#L69-L72
- https://github.com/brianc/node-postgres/blob/master/packages/pg/lib/connection-parameters.js#L30-L31
- https://github.com/brianc/node-postgres/blob/master/packages/pg-connection-string/index.js#L98-L101
- https://github.com/brianc/node-postgres/issues/2720